### PR TITLE
Dev/rotation bugfix

### DIFF
--- a/GUI/Model/GenericSliceModel.h
+++ b/GUI/Model/GenericSliceModel.h
@@ -396,6 +396,16 @@ public:
 
   DeformationGridModel *GetDeformationGridModel();
 
+  /**
+   * Voxelize a 2d polygon (represented by list of 2d vertices) into
+   * the segmentation slice of this model
+   * if invert == true, draw foreground within the polygon and backgournd outside
+   * if reverse = true, draw background with within the polygon
+   */
+  void Voxelize2DPolygonToSegmentationSlice(
+      const std::vector<Vector2d> &vts2d, const std::string &undoTitle,
+      bool invert = false, bool reverse = false);
+
 
 protected:
 

--- a/GUI/Model/PaintbrushModel.cxx
+++ b/GUI/Model/PaintbrushModel.cxx
@@ -167,6 +167,11 @@ void PaintbrushModel::ComputeMousePosition(const Vector3d &xSlice)
     }
 }
 
+bool PaintbrushModel::HasMainImageTransformed()
+{
+  return !m_Parent->GetDriver()->GetMainImage()->ImageSpaceMatchesReferenceSpace();
+}
+
 bool PaintbrushModel::TestInside(const Vector2d &x, const PaintbrushSettings &ps)
 {
   return this->TestInside(Vector3d(x(0), x(1), 0.0), ps);

--- a/GUI/Model/PaintbrushModel.cxx
+++ b/GUI/Model/PaintbrushModel.cxx
@@ -471,138 +471,29 @@ Vector3d PaintbrushModel::GetCenterOfPaintbrushInSliceSpace()
     return m_Parent->MapImageToSlice(to_double(m_MousePosition) + Vector3d(0.5));
 }
 
-#include <vtkNew.h>
-#include <vtkPoints.h>
-#include <vtkPolyData.h>
-#include <vtkContourTriangulator.h>
-#include "DrawTriangles.h"
-
 bool
 PaintbrushModel
 ::ApplyBrushByPolygonRasterization(bool reverse_mode, bool dragging)
 {
-  std::cout << "[PaintbrushModel::ApplyByPolygon] reverse: "
-            << reverse_mode << ", dragging: " << dragging << std::endl;
-
-  std::cout << "-- number of brush points: " << m_BrushPoints->GetNumberOfPoints()
-            << std::endl;
-
-  LabelImageWrapper *seg = this->m_Parent->GetDriver()->GetSelectedSegmentationLayer();
-
-  // build polygon
+  // build 2d vertices
+  std::vector<Vector2d> vts2d;
   auto np = m_BrushPoints->GetNumberOfPoints();
-  auto z = m_Parent->GetCursorPositionInSliceCoordinates()[2];
   Vector3d ctr = GetCenterOfPaintbrushInSliceSpace();
 
-//  std::cout << "-- z = " << z << std::endl;
-//  std::cout << "-- ctr: " << ctr << std::endl;
-  vtkNew<vtkPoints> pts;
-  pts->Allocate(np);
-
-  vtkNew<vtkPolyData> cont_pd; // the contour polydata
-  cont_pd->SetPoints(pts);
-  cont_pd->Allocate(np);
-
-  Vector3i ext_min, ext_max; // Extents of the polygon in voxel units
-
-  // process vertices and create edges
   for (int i = 0; i < np; ++i)
     {
-    double pt[2];
-    m_BrushPoints->GetPoint(i, pt);
+    double v[2];
+    m_BrushPoints->GetPoint(i, v);
+    // translate to center of pixel
+    v[0] += ctr[0];
+    v[1] += ctr[1];
 
-    // tranlsate to brush center
-    pt[0] += ctr[0];
-    pt[1] += ctr[1];
-
-    // transform point from display to image
-    Vector3d x_disp, x_ref;
-    x_disp[0] = pt[0];
-    x_disp[1] = pt[1];
-    x_disp[2] = z;
-
-    // transform to reference space first
-    x_ref = m_Parent->GetDisplayToImageTransform()->TransformPoint(x_disp);
-
-    // transform the point to actual image space
-    itk::ContinuousIndex<double, 3> ci_ref = to_itkContinuousIndex(x_ref), ci_vox;
-    seg->TransformReferenceCIndexToWrappedImageCIndex(ci_ref, ci_vox);
-
-//    std::cout << "-- point #" << i << ": " << x_disp;
-//    std::cout << " x_ref: " << x_ref;
-//    std::cout << " ci_vox: " << ci_vox << std::endl;
-
-    pts->InsertNextPoint(ci_vox[0], ci_vox[1], ci_vox[2]);
-
-    // Update the extents of the object
-    for(unsigned int j = 0; j < 3; j++)
-      {
-      int v = ci_vox[j];
-      ext_min[j] = (i == 0) ? v : std::min(v, ext_min[j]);
-      ext_max[j] = (i == 0) ? v : std::max(v, ext_max[j]);
-      }
-
-    // create an edge
-    vtkIdType vids[2]; // two vertices
-    vids[0] = i;
-    vids[1] = i < np - 1 ? i + 1 : 0;
-    cont_pd->InsertNextCell(VTK_LINE, 2, vids);
+    vts2d.push_back(Vector2d(v[0], v[1]));
     }
 
-  vtkNew<vtkContourTriangulator> fltContTri;
-  fltContTri->SetInputData(cont_pd);
-  fltContTri->Update();
-  auto tri_pd = fltContTri->GetOutput();
-
-  // Create a temporary RLE image for rasterization
-  itk::ImageRegion<3> seg_region(to_itkIndex(ext_min), to_itkSize(1 + ext_max - ext_min));
-  seg_region.Crop(seg->GetBufferedRegion());
-
-  LabelImageWrapper::ImagePointer seg_temp = LabelImageWrapper::ImageType::New();
-  auto *iseg = seg->GetModifiableImage();
-  seg_temp->CopyInformation(iseg);
-  seg_temp->SetRegions(seg_region);
-  seg_temp->Allocate();
-
-  // Convert the triangles into the data structure expected by scan converter and subtract
-  // the lower corner since the rasterization code expects the image to start at the
-  // coordinate zero
-  double **varr = new double *[tri_pd->GetNumberOfCells() * 3];
-  for(unsigned int i = 0; i < tri_pd->GetNumberOfCells(); i++)
-    {
-    for(unsigned int j = 0; j < 3; j++)
-      {
-      varr[i * 3 + j] = new double[3];
-      tri_pd->GetPoint(tri_pd->GetCell(i)->GetPointId(j), varr[i * 3 + j]);
-      for(unsigned int k = 0; k < 3; k++)
-        varr[i * 3 + j][k] -= ext_min[k];
-      }
-    }
-
-  // Image dimensions
-  int seg_dim[3] = { (int) seg_region.GetSize()[0], (int) seg_region.GetSize()[1], (int) seg_region.GetSize()[2] };
-  int w_line = seg_dim[2];
-
-  // Get the segmentation image and create an iterator for it
-  using RLEIter = itk::ImageRegionIterator<LabelImageWrapper::ImageType>;
-  RLEIter it_temp(seg_temp, seg_region);
-
-  // Create a lambda that can update pixels in an RLE image via the iterator
-  auto functor = [&it_temp](auto *img, int offset)
-    {
-    // Go to the indexed vertex and set value to 1
-    it_temp.SetIndex(img->ComputeIndex(offset));
-    it_temp.Set(1);
-    };
-
-  // Actual call to the scan conversion code
-  // DrawBinaryTrianglesSheetFilled(seg->GetModifiableImage(), seg_dim, varr, tri_pd->GetNumberOfCells(), functor);
-  cpu_voxelizer::DrawBinaryTrianglesSheetFilled(seg_temp.GetPointer(), seg_dim, varr, tri_pd->GetNumberOfCells(), functor);
-
-  // Update the segmentation via IRIS
-  m_Parent->GetDriver()->UpdateSegmentationWithBinarySegmentation(seg_temp, "Oblique Polygon Drawing");
-
+  // run voxelization code
+  m_Parent->Voxelize2DPolygonToSegmentationSlice(vts2d, "Oblique Paintbrush Update",
+                                                 false, reverse_mode);
   return true;
-
 }
 

--- a/GUI/Model/PaintbrushModel.cxx
+++ b/GUI/Model/PaintbrushModel.cxx
@@ -341,6 +341,9 @@ void PaintbrushModel::AcceptAtCursor()
 bool
 PaintbrushModel::ApplyBrush(bool reverse_mode, bool dragging)
 {
+  if (HasMainImageTransformed())
+    return ApplyBrushByPolygonRasterization(reverse_mode, dragging);
+
   // Get the global objects
   IRISApplication *driver = m_Parent->GetDriver();
   GlobalState *gs = driver->GetGlobalState();
@@ -467,3 +470,139 @@ Vector3d PaintbrushModel::GetCenterOfPaintbrushInSliceSpace()
   else
     return m_Parent->MapImageToSlice(to_double(m_MousePosition) + Vector3d(0.5));
 }
+
+#include <vtkNew.h>
+#include <vtkPoints.h>
+#include <vtkPolyData.h>
+#include <vtkContourTriangulator.h>
+#include "DrawTriangles.h"
+
+bool
+PaintbrushModel
+::ApplyBrushByPolygonRasterization(bool reverse_mode, bool dragging)
+{
+  std::cout << "[PaintbrushModel::ApplyByPolygon] reverse: "
+            << reverse_mode << ", dragging: " << dragging << std::endl;
+
+  std::cout << "-- number of brush points: " << m_BrushPoints->GetNumberOfPoints()
+            << std::endl;
+
+  LabelImageWrapper *seg = this->m_Parent->GetDriver()->GetSelectedSegmentationLayer();
+
+  // build polygon
+  auto np = m_BrushPoints->GetNumberOfPoints();
+  auto z = m_Parent->GetCursorPositionInSliceCoordinates()[2];
+  Vector3d ctr = GetCenterOfPaintbrushInSliceSpace();
+
+//  std::cout << "-- z = " << z << std::endl;
+//  std::cout << "-- ctr: " << ctr << std::endl;
+  vtkNew<vtkPoints> pts;
+  pts->Allocate(np);
+
+  vtkNew<vtkPolyData> cont_pd; // the contour polydata
+  cont_pd->SetPoints(pts);
+  cont_pd->Allocate(np);
+
+  Vector3i ext_min, ext_max; // Extents of the polygon in voxel units
+
+  // process vertices and create edges
+  for (int i = 0; i < np; ++i)
+    {
+    double pt[2];
+    m_BrushPoints->GetPoint(i, pt);
+
+    // tranlsate to brush center
+    pt[0] += ctr[0];
+    pt[1] += ctr[1];
+
+    // transform point from display to image
+    Vector3d x_disp, x_ref;
+    x_disp[0] = pt[0];
+    x_disp[1] = pt[1];
+    x_disp[2] = z;
+
+    // transform to reference space first
+    x_ref = m_Parent->GetDisplayToImageTransform()->TransformPoint(x_disp);
+
+    // transform the point to actual image space
+    itk::ContinuousIndex<double, 3> ci_ref = to_itkContinuousIndex(x_ref), ci_vox;
+    seg->TransformReferenceCIndexToWrappedImageCIndex(ci_ref, ci_vox);
+
+//    std::cout << "-- point #" << i << ": " << x_disp;
+//    std::cout << " x_ref: " << x_ref;
+//    std::cout << " ci_vox: " << ci_vox << std::endl;
+
+    pts->InsertNextPoint(ci_vox[0], ci_vox[1], ci_vox[2]);
+
+    // Update the extents of the object
+    for(unsigned int j = 0; j < 3; j++)
+      {
+      int v = ci_vox[j];
+      ext_min[j] = (i == 0) ? v : std::min(v, ext_min[j]);
+      ext_max[j] = (i == 0) ? v : std::max(v, ext_max[j]);
+      }
+
+    // create an edge
+    vtkIdType vids[2]; // two vertices
+    vids[0] = i;
+    vids[1] = i < np - 1 ? i + 1 : 0;
+    cont_pd->InsertNextCell(VTK_LINE, 2, vids);
+    }
+
+  vtkNew<vtkContourTriangulator> fltContTri;
+  fltContTri->SetInputData(cont_pd);
+  fltContTri->Update();
+  auto tri_pd = fltContTri->GetOutput();
+
+  // Create a temporary RLE image for rasterization
+  itk::ImageRegion<3> seg_region(to_itkIndex(ext_min), to_itkSize(1 + ext_max - ext_min));
+  seg_region.Crop(seg->GetBufferedRegion());
+
+  LabelImageWrapper::ImagePointer seg_temp = LabelImageWrapper::ImageType::New();
+  auto *iseg = seg->GetModifiableImage();
+  seg_temp->CopyInformation(iseg);
+  seg_temp->SetRegions(seg_region);
+  seg_temp->Allocate();
+
+  // Convert the triangles into the data structure expected by scan converter and subtract
+  // the lower corner since the rasterization code expects the image to start at the
+  // coordinate zero
+  double **varr = new double *[tri_pd->GetNumberOfCells() * 3];
+  for(unsigned int i = 0; i < tri_pd->GetNumberOfCells(); i++)
+    {
+    for(unsigned int j = 0; j < 3; j++)
+      {
+      varr[i * 3 + j] = new double[3];
+      tri_pd->GetPoint(tri_pd->GetCell(i)->GetPointId(j), varr[i * 3 + j]);
+      for(unsigned int k = 0; k < 3; k++)
+        varr[i * 3 + j][k] -= ext_min[k];
+      }
+    }
+
+  // Image dimensions
+  int seg_dim[3] = { (int) seg_region.GetSize()[0], (int) seg_region.GetSize()[1], (int) seg_region.GetSize()[2] };
+  int w_line = seg_dim[2];
+
+  // Get the segmentation image and create an iterator for it
+  using RLEIter = itk::ImageRegionIterator<LabelImageWrapper::ImageType>;
+  RLEIter it_temp(seg_temp, seg_region);
+
+  // Create a lambda that can update pixels in an RLE image via the iterator
+  auto functor = [&it_temp](auto *img, int offset)
+    {
+    // Go to the indexed vertex and set value to 1
+    it_temp.SetIndex(img->ComputeIndex(offset));
+    it_temp.Set(1);
+    };
+
+  // Actual call to the scan conversion code
+  // DrawBinaryTrianglesSheetFilled(seg->GetModifiableImage(), seg_dim, varr, tri_pd->GetNumberOfCells(), functor);
+  cpu_voxelizer::DrawBinaryTrianglesSheetFilled(seg_temp.GetPointer(), seg_dim, varr, tri_pd->GetNumberOfCells(), functor);
+
+  // Update the segmentation via IRIS
+  m_Parent->GetDriver()->UpdateSegmentationWithBinarySegmentation(seg_temp, "Oblique Polygon Drawing");
+
+  return true;
+
+}
+

--- a/GUI/Model/PaintbrushModel.h
+++ b/GUI/Model/PaintbrushModel.h
@@ -35,6 +35,9 @@ public:
   // should be rendered
   Vector3d GetCenterOfPaintbrushInSliceSpace();
 
+  // Get whether main image has been transformed
+  bool HasMainImageTransformed();
+
   bool TestInside(const Vector2d &x, const PaintbrushSettings &ps);
   bool TestInside(const Vector3d &x, const PaintbrushSettings &ps);
 

--- a/GUI/Model/PaintbrushModel.h
+++ b/GUI/Model/PaintbrushModel.h
@@ -3,10 +3,11 @@
 
 #include "AbstractModel.h"
 #include "GlobalState.h"
+#include <vtkSmartPointer.h>
+#include <vtkPoints2D.h>
 
 class GenericSliceModel;
 class BrushWatershedPipeline;
-
 
 class PaintbrushModel : public AbstractModel
 {
@@ -41,6 +42,9 @@ public:
   bool TestInside(const Vector2d &x, const PaintbrushSettings &ps);
   bool TestInside(const Vector3d &x, const PaintbrushSettings &ps);
 
+  // Getter and Setter for brush points
+  irisGetSetMacro(BrushPoints, vtkSmartPointer<vtkPoints2D>)
+
 protected:
 
   // Whether we are inverting the paintbrush when drawing
@@ -70,6 +74,13 @@ protected:
 
   GenericSliceModel *m_Parent;
   BrushWatershedPipeline *m_Watershed;
+
+  // Stores the brush points built by the renderer
+  vtkSmartPointer<vtkPoints2D> m_BrushPoints;
+
+  // Apply brush logic if main is transformed
+  // Returns true if changes were made
+  bool ApplyBrushByPolygonRasterization(bool reverse_mode, bool dragging);
 
   friend class PaintbrushRenderer;
 

--- a/GUI/Model/PolygonDrawingModel.cxx
+++ b/GUI/Model/PolygonDrawingModel.cxx
@@ -608,8 +608,6 @@ bool PolygonVertexTest(const PolygonVertex &v1, const PolygonVertex &v2)
   return v1.x == v2.x && v1.y == v2.y;
 }
 
-#include "DrawTriangles.h"
-
 /**
  * AcceptPolygon()
  *
@@ -651,117 +649,12 @@ PolygonDrawingModel
 
   if(!seg->ImageSpaceMatchesReferenceSpace())
     {
-    // Pointer to the segmentation image
-    auto *iseg = seg->GetModifiableImage();
+    std::vector<Vector2d> vts2d;
+    for (auto &v : m_Vertices)
+      vts2d.push_back(Vector2d(v.x, v.y));
 
-    // Perform 2D contour triangulation from the polygon data
-    vtkNew<vtkPoints> cont_pts;
-    vtkNew<vtkPolyData> cont_pd;
-    vtkNew<vtkContourTriangulator> cont_tri;
-
-    // Create the contour from the polygon
-    cont_pts->Allocate(m_Vertices.size());
-    cont_pd->SetPoints(cont_pts);
-    cont_pd->Allocate(m_Vertices.size());
-
-    // Allocate the data structure for 3D scan conversion
-    int i = 0;
-    for(auto &v : m_Vertices)
-      {
-      cont_pts->InsertNextPoint(v.x, v.y, 0.0);
-      vtkIdType ids[2];
-      ids[0] = i;
-      ids[1] = i < m_Vertices.size()-1 ? i+1 : 0;
-      cont_pd->InsertNextCell(VTK_LINE, 2, ids);
-      i++;
-      }
-
-    // Perform triangulation
-    cont_tri->SetInputData(cont_pd);
-    cont_tri->Update();
-    vtkPolyData *tri_pd = cont_tri->GetOutput();
-
-    // Extents of the polygon in voxel units
-    Vector3i ext_min, ext_max;
-
-    // Transform the vertex coordinates to image space
-    for(unsigned int i = 0; i < tri_pd->GetNumberOfPoints(); i++)
-      {
-      // Get the display coordinates
-      Vector3d x_disp, x_ref;
-      x_disp[0] = tri_pd->GetPoint(i)[0];
-      x_disp[1] = tri_pd->GetPoint(i)[1];
-      x_disp[2] = m_Parent->GetCursorPositionInSliceCoordinates()[2];
-
-      // Transform the point to reference space coordinates
-      x_ref = this->GetParent()->GetDisplayToImageTransform()->TransformPoint(x_disp);
-
-      // Transform the point to actual voxel coordinates of the wrapped segmentation image
-      itk::ContinuousIndex<double, 3> ci_ref = to_itkContinuousIndex(x_ref), ci_vox;
-      seg->TransformReferenceCIndexToWrappedImageCIndex(ci_ref, ci_vox);
-
-      // Update the points in the VTK data structure
-      tri_pd->GetPoints()->SetPoint(i, ci_vox.GetDataPointer());
-
-      // Print point
-      printf("Point %02d   %6.3f %6.3f %6.3f \n", i, ci_vox[0], ci_vox[1], ci_vox[2]);
-
-      // Update the extents of the object
-      for(unsigned int j = 0; j < 3; j++)
-        {
-        int v = ci_vox[j];
-        ext_min[j] = (i == 0) ? v : std::min(v, ext_min[j]);
-        ext_max[j] = (i == 0) ? v : std::max(v, ext_max[j]);
-        }
-      }
-
-    // Create a new RLE representation of the segmentation.
-    itk::ImageRegion<3> seg_region(to_itkIndex(ext_min), to_itkSize(1 + ext_max - ext_min));
-    seg_region.Crop(seg->GetBufferedRegion());
-
-    LabelImageWrapper::ImagePointer seg_temp = LabelImageWrapper::ImageType::New();
-    seg_temp->CopyInformation(iseg);
-    seg_temp->SetRegions(seg_region);
-    seg_temp->Allocate();
-
-    // Convert the triangles into the data structure expected by scan converter and subtract
-    // the lower corner since the rasterization code expects the image to start at the
-    // coordinate zero
-    double **varr = new double *[tri_pd->GetNumberOfCells() * 3];
-    for(unsigned int i = 0; i < tri_pd->GetNumberOfCells(); i++)
-      {
-      for(unsigned int j = 0; j < 3; j++)
-        {
-        varr[i * 3 + j] = new double[3];
-        tri_pd->GetPoint(tri_pd->GetCell(i)->GetPointId(j), varr[i * 3 + j]);
-        for(unsigned int k = 0; k < 3; k++)
-          varr[i * 3 + j][k] -= ext_min[k];
-        }
-      }
-
-    // Image dimensions
-    int seg_dim[3] = { (int) seg_region.GetSize()[0], (int) seg_region.GetSize()[1], (int) seg_region.GetSize()[2] };
-    int w_line = seg_dim[2];
-
-    // Get the segmentation image and create an iterator for it
-    using RLEIter = itk::ImageRegionIterator<LabelImageWrapper::ImageType>;
-    RLEIter it_temp(seg_temp, seg_region);
-
-
-    // Create a lambda that can update pixels in an RLE image via the iterator
-    auto functor = [&it_temp](auto *img, int offset)
-      {
-      // Go to the indexed vertex and set value to 1
-      it_temp.SetIndex(img->ComputeIndex(offset));
-      it_temp.Set(1);
-      };
-
-    // Actual call to the scan conversion code
-    // DrawBinaryTrianglesSheetFilled(seg->GetModifiableImage(), seg_dim, varr, tri_pd->GetNumberOfCells(), functor);
-    cpu_voxelizer::DrawBinaryTrianglesSheetFilled(seg_temp.GetPointer(), seg_dim, varr, tri_pd->GetNumberOfCells(), functor);
-
-    // Update the segmentation via IRIS
-    m_Parent->GetDriver()->UpdateSegmentationWithBinarySegmentation(seg_temp, "Oblique Polygon Drawing");
+    bool invert = m_Parent->GetDriver()->GetGlobalState()->GetPolygonInvert();
+    m_Parent->Voxelize2DPolygonToSegmentationSlice(vts2d, "Oblique Polygon Drawing", invert, false);
     }
   else
     {

--- a/GUI/Renderer/PaintbrushRenderer.cxx
+++ b/GUI/Renderer/PaintbrushRenderer.cxx
@@ -146,6 +146,8 @@ public:
     // Build the mask edges
     BuildBrush();
 
+    m_PaintbrushModel->SetBrushPoints(m_Walk);
+
     // Apply the line properties
     this->ApplyAppearanceSettingsToPen(painter, elt);
 

--- a/Logic/Framework/IRISApplication.cxx
+++ b/Logic/Framework/IRISApplication.cxx
@@ -652,7 +652,7 @@ IRISApplication
 unsigned int
 IRISApplication
 ::UpdateSegmentationWithBinarySegmentation(
-    const LabelImageType *binseg, const std::string &undoTitle)
+    const LabelImageType *binseg, const std::string &undoTitle, bool invert, bool reverse)
 {
   // Work out the 3D region to merge
   RegionType r_vol = binseg->GetBufferedRegion();
@@ -663,13 +663,16 @@ IRISApplication
                                     m_GlobalState->GetDrawingColorLabel(),
                                     m_GlobalState->GetDrawOverFilter());
 
-  // Drawing parameters
-  bool invert = m_GlobalState->GetPolygonInvert();
-
   // Iterate over the volume region
   for(LabelImageWrapper::ConstIterator it_src(binseg, r_vol); !it_src.IsAtEnd(); ++it_src, ++it_trg)
     if((it_src.Get() != 0) ^ invert)
-      it_trg.PaintAsForeground();
+      {
+      if (it_src.Get() != 0 && reverse)
+        it_trg.PaintAsBackground();
+      else
+        it_trg.PaintAsForeground();
+      }
+
 
   // Finalize
   if(it_trg.Finalize(undoTitle.c_str()))

--- a/Logic/Framework/IRISApplication.h
+++ b/Logic/Framework/IRISApplication.h
@@ -603,9 +603,12 @@ public:
 
   /**
    * Apply a binary drawing represented as an RLE image
+   * if invert == true, draw foreground with value 1 and background with 0
+   * if reverse = true, draw background with value 1
    */
   unsigned int UpdateSegmentationWithBinarySegmentation(
-      const LabelImageType *binseg, const std::string &undoTitle);
+      const LabelImageType *binseg, const std::string &undoTitle,
+      bool invert = false, bool reverse = false);
 
   /** Get the pointer to the settings used for threshold-based preprocessing */
   // irisGetMacro(ThresholdSettings, ThresholdSettings *)


### PR DESCRIPTION
- Now paintbrush will use polygon rasterization to draw when main image is transformed
- Moved the voxelization code to `GenericSliceModel` level so it can be used by both polygon and paintbrush
- Modified the segmentation update code to be more generic