### PR TITLE
New prompt logic for loading 3d segmentation

### DIFF
--- a/GUI/Model/ImageIOWizardModel.cxx
+++ b/GUI/Model/ImageIOWizardModel.cxx
@@ -300,6 +300,20 @@ ImageIOWizardModel::FileFormat ImageIOWizardModel::GetSelectedFormat()
   return GuidedNativeImageIO::GetFileFormat(m_Registry);
 }
 
+bool
+ImageIOWizardModel
+::CanLoadOverwriteUnsavedChanges(std::string filename)
+{
+  // only check when loading segmentation
+  auto segDel = dynamic_cast<LoadSegmentationImageDelegate*>(m_LoadDelegate.GetPointer());
+  if (segDel)
+    {
+    return segDel->CanLoadOverwriteUnsavedChanges(m_GuidedIO, filename);
+    }
+
+  return false;
+}
+
 
 
 void ImageIOWizardModel::OpenImage(std::string filename, ImageReadingProgressAccumulator *irAccum)

--- a/GUI/Model/ImageIOWizardModel.h
+++ b/GUI/Model/ImageIOWizardModel.h
@@ -224,6 +224,10 @@ public:
   /** Which is the colormap of the sticky overlay */
   irisSimplePropertyAccessMacro(StickyOverlayColorMap, std::string)
 
+  /** Check if current loading may cause unsaved change lost */
+  bool CanLoadOverwriteUnsavedChanges(std::string filename);
+
+
 protected:
 
   // Standard ITK protected constructors

--- a/GUI/Qt/Windows/DropActionDialog.cxx
+++ b/GUI/Qt/Windows/DropActionDialog.cxx
@@ -182,12 +182,16 @@ void DropActionDialog::on_btnLoadMeshToTP_clicked()
 
 void DropActionDialog::on_btnLoadSegmentation_clicked()
 {
-  // Prompt for unsaved changes before replacing the segmentation
-  if(!SaveModifiedLayersDialog::PromptForUnsavedSegmentationChanges(m_Model))
-    return;
-
   SmartPtr<LoadSegmentationImageDelegate> del = LoadSegmentationImageDelegate::New();
   del->Initialize(m_Model->GetDriver());
+
+  auto io = GuidedNativeImageIO::New();
+
+  // if incoming load can overwrite unsaved changes, prompt user for saving
+  if (del->CanLoadOverwriteUnsavedChanges(io, to_utf8(ui->outFilename->text())) &&
+      !SaveModifiedLayersDialog::PromptForUnsavedSegmentationChanges(m_Model))
+    return;
+
   this->LoadCommon(del);
 }
 

--- a/GUI/Qt/Windows/MainImageWindow.cxx
+++ b/GUI/Qt/Windows/MainImageWindow.cxx
@@ -1130,7 +1130,9 @@ void MainImageWindow::on_actionQuit_triggered()
 void MainImageWindow::on_actionLoad_from_Image_triggered()
 {
   // Prompt for unsaved changes
-  if(!SaveModifiedLayersDialog::PromptForUnsavedSegmentationChanges(m_Model))
+  // -- only prompt for 3d
+  if(m_Model->GetDriver()->GetNumberOfTimePoints() == 1 &&
+     !SaveModifiedLayersDialog::PromptForUnsavedSegmentationChanges(m_Model))
     return;
 
   // Create a model for IO

--- a/Logic/Framework/ImageIODelegates.cxx
+++ b/Logic/Framework/ImageIODelegates.cxx
@@ -274,6 +274,28 @@ LoadSegmentationImageDelegate
   // just will reinitialize it with zeros. It's safe to just do nothing.
 }
 
+bool
+LoadSegmentationImageDelegate
+::CanLoadOverwriteUnsavedChanges(GuidedNativeImageIO *io, std::string filename)
+{
+  auto header = io->PeekHeader(filename);
+  auto nDimIncoming = header->GetNumberOfDimensions();
+  auto nt = m_Driver->GetNumberOfTimePoints();
+
+  // for 4d workspace
+  if (nt > 1)
+    {
+    auto layer = m_Driver->GetSelectedSegmentationLayer();
+    auto crntTP = m_Driver->GetCursorTimePoint();
+    // true case 1: incoming image is 4d
+    // true case 2: incoming 3d but unsaved changes are in the current time point
+    if (nDimIncoming > 3 || layer->HasUnsavedChanges(crntTP))
+      return true;
+    }
+
+  return false;
+}
+
 
 void
 DefaultSaveImageDelegate::Initialize(

--- a/Logic/Framework/ImageIODelegates.h
+++ b/Logic/Framework/ImageIODelegates.h
@@ -153,6 +153,9 @@ public:
   void UnloadCurrentImage() ITK_OVERRIDE;
   ImageWrapperBase * UpdateApplicationWithImage(GuidedNativeImageIO *io) ITK_OVERRIDE;
 
+  /* check if the load could overwrite unsaved changes */
+  bool CanLoadOverwriteUnsavedChanges(GuidedNativeImageIO *io, std::string filename);
+
 protected:
   // TODO: this is probably a temporary band-aid. In some situations, we want to be
   // able to load segmentation images as the one and only segmentation layer and in

--- a/Logic/ImageWrapper/GuidedNativeImageIO.cxx
+++ b/Logic/ImageWrapper/GuidedNativeImageIO.cxx
@@ -2214,6 +2214,15 @@ void GuidedNativeImageIO::DicomDirectoryParseResult::Reset()
   SeriesMap.clear();
 }
 
+GuidedNativeImageIO::IOBasePointer
+GuidedNativeImageIO
+::PeekHeader(std::string filename)
+{
+  Registry dummyRegistry;
+  ReadNativeImageHeader(filename.c_str(), dummyRegistry);
+  return m_IOBase;
+}
+
 /*
 {
   // Must have a directory

--- a/Logic/ImageWrapper/GuidedNativeImageIO.h
+++ b/Logic/ImageWrapper/GuidedNativeImageIO.h
@@ -299,6 +299,7 @@ public:
     m_LoadMultiComponentAs4D = !value;
   }
 
+  IOBasePointer PeekHeader(std::string filename);
 
   // Get the output of the last operation
   // irisGetMacro(IOBase, itk::ImageIOBase *);

--- a/Logic/ImageWrapper/ImageWrapper.cxx
+++ b/Logic/ImageWrapper/ImageWrapper.cxx
@@ -2496,6 +2496,19 @@ ImageWrapper<TTraits>
 }
 
 template<class TTraits>
+bool
+ImageWrapper<TTraits>
+::HasUnsavedChanges(unsigned int tp) const
+{
+  if (m_ImageTimePoints.size() <= tp)
+    return false;
+
+  auto img = m_ImageTimePoints[tp];
+  return img->GetTimeStamp() > m_ImageSaveTime;
+}
+
+
+template<class TTraits>
 void
 ImageWrapper<TTraits>
 ::SetSourceNativeMapping(double scale, double shift)

--- a/Logic/ImageWrapper/ImageWrapper.h
+++ b/Logic/ImageWrapper/ImageWrapper.h
@@ -709,6 +709,11 @@ public:
   virtual bool HasUnsavedChanges() const ITK_OVERRIDE;
 
   /**
+   * Check if the time point has unsaved changes
+   */
+  virtual bool HasUnsavedChanges(unsigned int tp) const ITK_OVERRIDE;
+
+  /**
    * This method is only used when this wrapper is around an image adaptor
    * (e.g., magnitude of component vector) and we need to update the native
    * mapping used in the adapter as part of the calculation. This is because

--- a/Logic/ImageWrapper/ImageWrapperBase.h
+++ b/Logic/ImageWrapper/ImageWrapperBase.h
@@ -428,6 +428,11 @@ public:
   virtual bool HasUnsavedChanges() const = 0;
 
   /**
+   * Check if the time point has unsaved changes
+   */
+  virtual bool HasUnsavedChanges(unsigned int tp) const = 0;
+
+  /**
    * Save metadata to a Registry file. The metadata are data that are not
    * contained in the image header are need to be restored when the image
    * is reloaded. Currently, this mainly includes the display mapping, but


### PR DESCRIPTION
- The check logic is written in LoadSegmentationImageDelegate so it can be reused in both DropActionDialog and ImageIOWizard
- For non-4d workspace it will always prompt
- For 4d workspace, if the incoming image is 4d, always prompt
- For 4d workspace, if the incoming image is 3d, prompt when unsaved changes are in current tp